### PR TITLE
Fixes: MSSQL main service not added to health check

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,6 +7,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-mssql/milestones?state=closed).
 
+## 1.2.0 (2021-06-02)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/4?closed=1)
+
+### Bugfixes
+
+* [32](https://github.com/Icinga/icinga-powershell-mssql/issues/32) Fixes `MSSQLSERVER` service not being added by default for `Invoke-IcingaCheckMSSQLHealth`
+
 ## 1.1.0 (2021-03-02)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/2?closed=1)

--- a/plugins/Invoke-IcingaCheckMSSQLHealth.psm1
+++ b/plugins/Invoke-IcingaCheckMSSQLHealth.psm1
@@ -119,7 +119,7 @@ function Invoke-IcingaCheckMSSQLHealth()
         $StatusRaw     = $ServiceObject.configuration.Status.raw;
 
         # Now check if our instance name is either matching the exact service name of the instance name
-        if ($service -eq $Instance -Or $service -eq ([string]::Format('MSSQL${0}', $Instance))) {
+        if ($service -eq 'MSSQLSERVER' -Or $service -eq $Instance -Or $service -eq ([string]::Format('MSSQL${0}', $Instance))) {
             $ServiceCheck = New-IcingaCheck -Name $ServiceName -Value $StatusRaw -ObjectExists $service -Translation $ProviderEnums.ServiceStatusName;
             $ServiceCheck.CritIfNotMatch($ProviderEnums.ServiceStatus.Running) | Out-Null;
             $MSSQLCheckPackage.AddCheck($ServiceCheck);


### PR DESCRIPTION
Fixes `MSSQLSERVER` service not being added by default for `Invoke-IcingaCheckMSSQLHealth`