### PR TITLE
Fix: Backup status plugin for MSSQL which ignored NoPerfData flag

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -13,7 +13,8 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## Bugfixes
 
-* [#61](https://github.com/Icinga/icinga-powershell-mssql/pull#61) Update queries for performance counters to allow (and use) wildcards. Fixes #50
+* [#54](https://github.com/Icinga/icinga-powershell-mssql/issues/54) Fixes `Invoke-IcingaCheckMSSQLBackupStatus` which ignored the `-NoPerfData` flag
+* [#61](https://github.com/Icinga/icinga-powershell-mssql/pull/61) Update queries for performance counters to allow (and use) wildcards. Fixes #50
 
 ### Enhancements
 

--- a/plugins/Invoke-IcingaCheckMSSQLBackupStatus.psm1
+++ b/plugins/Invoke-IcingaCheckMSSQLBackupStatus.psm1
@@ -119,7 +119,7 @@ function Invoke-IcingaCheckMSSQLBackupStatus
         [string]$SqlHost            = "localhost",
         [int]$SqlPort               = 1433,
         [switch]$IntegratedSecurity = $FALSE,
-        [switch]$NoPerfData,
+        [switch]$NoPerfData         = $FALSE,
         $IncludeDays                = $null,
         [ValidateSet(0, 1, 2, 3)]
         $Verbosity                  = 0
@@ -174,5 +174,5 @@ function Invoke-IcingaCheckMSSQLBackupStatus
         $CheckPackage.AddCheck($DBPackage);
     }
 
-    return (New-IcingaCheckResult -Check $CheckPackage -Compile);
+    return (New-IcingaCheckResult -Check $CheckPackage -Compile -NoPerfData $NoPerfData);
 }


### PR DESCRIPTION
Fixes `Invoke-IcingaCheckMSSQLBackupStatus` which ignored the `-NoPerfData` flag

Fixes #54