### PR TITLE
Fixes MSSQL backup check to not throw unknown if no backup exist

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/10?closed=1)
 
+## 1.6.1 (2025-11-06)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/11?closed=1)
+
+* [#64](https://github.com/Icinga/icinga-powershell-mssql/pull/64) Fixes MSSQL backup check which threw `UNKNOWN` on MSSQL instances which have had no backups yet
+
 ## 1.6.0 (2025-09-23)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/8?closed=1)

--- a/plugins/Invoke-IcingaCheckMSSQLBackupStatus.psm1
+++ b/plugins/Invoke-IcingaCheckMSSQLBackupStatus.psm1
@@ -140,7 +140,7 @@ function Invoke-IcingaCheckMSSQLBackupStatus
     $SqlConnection         = Open-IcingaMSSQLConnection -Username $SqlUsername -Password $SqlPassword -Address $SqlHost -IntegratedSecurity:$IntegratedSecurity -Port $SqlPort;
     $BackupSet             = Get-IcingaMSSQLBackupOverallStatus -SqlConnection $SqlConnection -IncludeDatabase $IncludeDatabase -IncludeDays $IncludeDays;
     $InstanceName          = Get-IcingaMSSQLInstanceName -SqlConnection $SqlConnection;
-    $CheckPackage          = New-IcingaCheckPackage -Name ([string]::Format('MSSQL Backup ({0})', $InstanceName)) -OperatorAnd -Verbose $Verbosity;
+    $CheckPackage          = New-IcingaCheckPackage -Name ([string]::Format('MSSQL Backup ({0})', $InstanceName)) -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage;
 
     Close-IcingaMSSQLConnection -SqlConnection $SqlConnection;
 


### PR DESCRIPTION
Fixes MSSQL backup check which threw `UNKNOWN` on MSSQL instances which have had no backups yet