### PR TITLE
Fix: MSSQL Backup check to only include backup data for present databases

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -7,9 +7,13 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-mssql/milestones?state=closed).
 
-## 1.7.0 (tbd)
+## 1.7.0 (2026-06-30)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-mssql/milestone/10?closed=1)
+
+### Bugfixes
+
+* [#66](https://github.com/Icinga/icinga-powershell-mssql/pull/66) Fixes MSSQL Backup check to use `INNER` instead of `LEFT` join to only include backup data for existing databases
 
 ## 1.6.1 (2025-11-06)
 

--- a/provider/mssql/Get-IcingaMSSQLBackupOverallStatus.psm1
+++ b/provider/mssql/Get-IcingaMSSQLBackupOverallStatus.psm1
@@ -87,7 +87,7 @@ function Get-IcingaMSSQLBackupOverallStatus
                 DATEDIFF(MI, msdb.dbo.backupset.backup_start_date,  msdb.dbo.backupset.backup_finish_date) AS last_backup_duration_min
             FROM msdb.dbo.backupmediafamily
                 INNER JOIN msdb.dbo.backupset ON msdb.dbo.backupmediafamily.media_set_id = msdb.dbo.backupset.media_set_id
-                LEFT JOIN sys.databases ON sys.databases.name = msdb.dbo.backupset.database_name
+                INNER JOIN sys.databases ON sys.databases.name = msdb.dbo.backupset.database_name
             WHERE sys.databases.source_database_id IS NULL";
 
     if ($null -ne $IncludeDays) {


### PR DESCRIPTION
Fixes MSSQL Backup check to use `INNER` instead of `LEFT` join to only include backup data for existing databases